### PR TITLE
Added beforeAdd & beforeDelete functions

### DIFF
--- a/jquery.repeatable.js
+++ b/jquery.repeatable.js
@@ -13,7 +13,9 @@
 			startWith: 0,
 			template: null,
 			itemContainer: ".field-group",
+			beforeAdd: function () {},
 			onAdd: function () {},
+			beforeDelete: function () {},
 			onDelete: function () {}
 		};
 
@@ -56,6 +58,7 @@
 		 */
 		var addOne = function (e) {
 			e.preventDefault();
+			settings.beforeAdd.call(this);
 			createOne();
 			settings.onAdd.call(this);
 		};
@@ -68,6 +71,7 @@
 		 */
 		var deleteOne = function (e) {
 			e.preventDefault();
+			settings.beforeDelete.call(this);
 			$(this).parents(settings.itemContainer).first().remove();
 			total--;
 			maintainAddBtn();


### PR DESCRIPTION
Issue:

You have a plugin like Select2 on your drop downs, which are repeatable elements.

Select2 won't work on new elements created by jQuery.Repeatable, so it requires the user to use the destroy method before the DOM changes and then call the function again after the DOM has changed.

And of course it works for any other situations when we need something to happen before the DOM change. Like an alert();

I'll add an example to the readme if you like.

:)